### PR TITLE
MRG: Add install target to makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ script:
   - mkdir tmp_for_tests
   - cp Makefile tmp_for_tests/.
   - cd tmp_for_tests
-  - make test
-  - make style
+  - make test-fast
+  - make style-fast
 
 after_success:
   - if [ "${COVERAGE}" == "1" ]; then coveralls; fi

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,26 @@
-test:
+.PHONY: install
+install:
+	pip install -r requirements.txt --quiet
+	pip install -e .
+
+all: install test-fast style-fast
+
+test: install
 	py.test --cov=mousestyles --pyargs mousestyles
+
+style: install
+	py.test --pep8 --flakes --pyargs mousestyles
 
 clean:
 	find . -name "*.so" -o -name "*.pyc" -o -name "*.pyx.md5" | xargs rm -f
 	find . -name "__pycache__" -o -name ".cache" | xargs rm -rf
 	rm -rf build dist mousestyles.egg-info
 
-style:
-	py.test --pep8 --flakes --pyargs mousestyles
+# warning: the following targets don't ensure that the package is up-to-date
+# only use these after running make install
 
+test-fast:
+	py.test --cov=mousestyles --pyargs mousestyles
+
+style-fast:
+	py.test --pep8 --flakes --pyargs mousestyles

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ clean:
 	find . -name "__pycache__" -o -name ".cache" | xargs rm -rf
 	rm -rf build dist mousestyles.egg-info
 
-# warning: the following targets don't ensure that the package is up-to-date
-# only use these after running make install
+# warning: the following targets don't ensure that the package is up-to-date.
+# only use these after running make install.
 
 test-fast:
 	py.test --cov=mousestyles --pyargs mousestyles

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -4,5 +4,6 @@
 ## which will hopefully guarantee a fairly smooth Travis build.
 ## If necessary, you can force a commit using the --no-verify flag.
 
-make test
-make style
+make install
+make test-fast
+make style-fast

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -4,6 +4,4 @@
 ## which will hopefully guarantee a fairly smooth Travis build.
 ## If necessary, you can force a commit using the --no-verify flag.
 
-make install
-make test-fast
-make style-fast
+make all


### PR DESCRIPTION
Addresses #47.
`make test` and `make style` always run `make install`, so I've added `make test-fast` and `make style-fast` for quicker (but less foolproof) development.