### PR TITLE
MRG: Add functions to compute path length and average speed

### DIFF
--- a/mousestyles/path_diversity/get_dist_speed.py
+++ b/mousestyles/path_diversity/get_dist_speed.py
@@ -3,10 +3,10 @@ from __future__ import print_function, absolute_import, division
 import numpy as np
 
 
-def get_dist_speed(movement, start, end):
+def get_dist_speed(movement, start, end, return_array=True):
     r"""
-    Return a tuple containing distance covered in a path and
-    average speed within a path.
+    Return a list containing distance(s) covered in a path and
+    average speed(s) within a path.
 
     Parameters
     ----------
@@ -20,17 +20,30 @@ def get_dist_speed(movement, start, end):
     end : int
         positive integer indicating the end index of a path
 
+    return_array : bool
+        boolean indicating whether an array of distances and
+        average speeds are returned or the summation of those
+        distances and speeds
+
     Returns
     -------
-    dist : distance travelled along a path
+    dist : distance(s) travelled along a path
 
-    speed : average speed along a path
+    speed : average speed(s) along a path
 
     Examples
     --------
     >>> movement = data.load_movement(1, 2, 1)
-    >>> dist, speed = get_dist_speed(movement, 0, 500)
-    (554.5573324808769, 0.080910098911799441)
+    >>> dist, speed = get_dist_speed(movement, 0, 3)
+    >>> print(dist)
+    [0.0, 0.17999999999999972, 0.19446593532030554]
+    >>> print(speed)
+    [0.0, 0.9999999999983815, 0.055246004352409776]
+    >>> dist, speed = get_dist_speed(movement, 0, 3, return_array=False)
+    >>> print(dist)
+    0.37446593532030525
+    >>> print(speed)
+    0.096661315260887087
     """
 
     # Check whether inputs are valid.
@@ -49,9 +62,16 @@ def get_dist_speed(movement, start, end):
 
     x = movement['x'][start:(end+1)].ravel()
     y = movement['y'][start:(end+1)].ravel()
-    t = movement['t']
-    time = t[end] - t[start]
 
-    dist = sum(np.sqrt((x[1:] - x[:-1])**2 + (y[1:] - y[:-1])**2))
-    speed = dist / time
-    return(dist, speed)
+    if return_array:
+        t = movement['t'][start:(end+1)].ravel()
+        time = np.diff(t)
+        dist = np.sqrt((x[1:] - x[:-1])**2 + (y[1:] - y[:-1])**2).tolist()
+        speed = (dist / time).tolist()
+    else:
+        t = movement['t']
+        time = t[end] - t[start]
+        dist = sum(np.sqrt((x[1:] - x[:-1])**2 + (y[1:] - y[:-1])**2))
+        speed = dist / time
+
+    return([dist, speed])

--- a/mousestyles/path_diversity/get_dist_speed.py
+++ b/mousestyles/path_diversity/get_dist_speed.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, absolute_import, division
-import numpy as np 
+
+import numpy as np
 
 
 def get_dist_speed(movement, start, end):
@@ -53,5 +54,4 @@ def get_dist_speed(movement, start, end):
 
     dist = sum(np.sqrt((x[1:] - x[:-1])**2 + (y[1:] - y[:-1])**2))
     speed = dist / time
-
     return(dist, speed)

--- a/mousestyles/path_diversity/get_dist_speed.py
+++ b/mousestyles/path_diversity/get_dist_speed.py
@@ -1,5 +1,5 @@
 from __future__ import print_function, absolute_import, division
-import math
+import numpy as np 
 
 
 def get_dist_speed(movement, start, end):
@@ -46,14 +46,12 @@ def get_dist_speed(movement, start, end):
     if start == end:
         return(0, 0)
 
-    x = movement['x']
-    y = movement['y']
+    x = movement['x'][start:(end+1)].ravel()
+    y = movement['y'][start:(end+1)].ravel()
     t = movement['t']
-    dist = 0
     time = t[end] - t[start]
-    while start < end:
-        dist += math.sqrt((x[start + 1] - x[start])**2 + (y[start + 1] -
-                                                          y[start])**2)
-        start += 1
+
+    dist = sum(np.sqrt((x[1:] - x[:-1])**2 + (y[1:] - y[:-1])**2))
     speed = dist / time
+
     return(dist, speed)

--- a/mousestyles/path_diversity/get_dist_speed.py
+++ b/mousestyles/path_diversity/get_dist_speed.py
@@ -1,0 +1,59 @@
+from __future__ import print_function, absolute_import, division
+import math
+
+
+def get_dist_speed(movement, start, end):
+    r"""
+    Return a tuple containing distance covered in a path and
+    average speed within a path.
+
+    Parameters
+    ----------
+    movement : pandas.DataFrame
+        CT, CX, CY coordinates and homebase status for the unique
+        combination of strain, mouse, and day
+
+    start : int
+        positive integer indicating the starting index of a path
+
+    end : int
+        positive integer indicating the end index of a path
+
+    Returns
+    -------
+    dist : distance travelled along a path
+
+    speed : average speed along a path
+
+    Examples
+    --------
+    >>> movement = data.load_movement(1, 2, 1)
+    >>> dist, speed = get_dist_speed(movement, 0, 500)
+    (554.5573324808769, 0.080910098911799441)
+    """
+
+    # Check whether inputs are valid.
+    if (start < 0) or (end < 0):
+        raise ValueError("Start and end indices must be positive")
+    if (type(start) != int) or (type(end) != int):
+        raise TypeError("Start and end indices must be integers")
+    if start > end:
+        raise ValueError("Start index must be smaller than end index")
+    if end - start > len(movement) - 1:
+        raise ValueError("Number of observations must be less than \
+        or equal to total observations")
+
+    if start == end:
+        return(0, 0)
+
+    x = movement['x']
+    y = movement['y']
+    t = movement['t']
+    dist = 0
+    time = t[end] - t[start]
+    while start < end:
+        dist += math.sqrt((x[start + 1] - x[start])**2 + (y[start + 1] -
+                                                          y[start])**2)
+        start += 1
+    speed = dist / time
+    return(dist, speed)

--- a/mousestyles/path_diversity/tests/test_dist_speed.py
+++ b/mousestyles/path_diversity/tests/test_dist_speed.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-
+import pandas as pd
 import pytest
 
 
@@ -33,7 +33,9 @@ def test_dist_speed_input():
 
 
 def test_dist_speed():
-    movement = data.load_movement(0, 0, 0)
+    movement = pd.DataFrame([[1, 1, 1], [2, 2, 1], [3, 2, 3]])
+    movement.columns = ['t', 'x', 'y']
     # Check if function produces the correct outputs.
-    dist, speed = get_dist_speed.get_dist_speed(movement, 0, 500)
-    assert dist == 540.850932793882 and speed == 0.68200564013190335
+    dist, speed = get_dist_speed.get_dist_speed(movement, 0, 2)
+    assert dist[0] == 1.0 and dist[1] == 2.0 and speed[0] == 1.0 and\
+        speed[1] == 2.0

--- a/mousestyles/path_diversity/tests/test_dist_speed.py
+++ b/mousestyles/path_diversity/tests/test_dist_speed.py
@@ -1,0 +1,39 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+
+import pytest
+
+
+from mousestyles import data
+from mousestyles.path_diversity import get_dist_speed
+
+
+def test_dist_speed_input():
+    movement = data.load_movement(0, 0, 0)
+    # Check if function raises the correct type of errors.
+    # Input negative numbers
+    with pytest.raises(ValueError) as excinfo:
+        get_dist_speed.get_dist_speed(movement, -1, -1)
+    assert excinfo.value.args[0] == "Start and end indices must be positive"
+    # Input non-integers
+    with pytest.raises(TypeError) as excinfo:
+        get_dist_speed.get_dist_speed(movement, 0.1, 0.1)
+    assert excinfo.value.args[0] == "Start and end indices must be integers"
+    # Input start index greater than end index
+    with pytest.raises(ValueError) as excinfo:
+        get_dist_speed.get_dist_speed(movement, 500, 2)
+    assert excinfo.value.args[
+        0] == "Start index must be smaller than end index"
+    # Input indices that encompass data outside of true data length
+    with pytest.raises(ValueError) as excinfo:
+        get_dist_speed.get_dist_speed(movement, 0, len(movement))
+    assert excinfo.value.args[0] == "Number of observations must be less than \
+        or equal to total observations"
+
+
+def test_dist_speed():
+    movement = data.load_movement(0, 0, 0)
+    # Check if function produces the correct outputs.
+    dist, speed = get_dist_speed.get_dist_speed(movement, 0, 500)
+    assert dist == 540.850932793882 and speed == 0.68200564013190335


### PR DESCRIPTION
Addresses the fourth bullet point of issue #122.
- Function get_dist_speed computes:
    - segment lengths or the total length of a path 
    - average speeds along the segments or average speed along a path
- Function test_dist_speed_input and test_dist_speed test input and functionality of get_dist_speed.
Feel free to review. Please let me know if anything needs to be changed. @alannaiverson @aksam-ahmad @jcpalumbo3 @jJasonWang @togawa28 