### PR TITLE
MRG: Add Function for Removing Duplicated Rows

### DIFF
--- a/mousestyles/path_diversity/clean_movements.py
+++ b/mousestyles/path_diversity/clean_movements.py
@@ -1,5 +1,6 @@
 import pandas as pd
 
+
 def clean_movements(movements, keep_index=False):
     r"""
     Returns a list of cleaned movement objects.
@@ -12,7 +13,7 @@ def clean_movements(movements, keep_index=False):
     Parameters
     ----------
     movements : list
-        each element is pandas.DataFrame containing 
+        each element is pandas.DataFrame containing
         CT, CX, CY coordinates.
         Should have length greater than 1.
 
@@ -31,27 +32,27 @@ def clean_movements(movements, keep_index=False):
     >>> strain_nums = [0,0,1,1,2,2]
     >>> mouse_nums = [0,0,1,1,2,2]
     >>> day_nums = [0,11,0,11,0,11]
-    >>> movements = [data.load_movement(strain_num, mouse_num, day_num) for \
-    >>> strain_num, mouse_num, day_num in zip(strain_nums, mouse_nums, day_nums)]
+    >>> movements = [data.load_movement(strain_num, mouse_num, day_num)
+                     for strain_num, mouse_num, day_num in
+                     zip(strain_nums, mouse_nums, day_nums)]
     >>> cleaned_movements = clean_movements(movements)
     """
-    
-    if type(movements) is not list:
+    if not isinstance(movements, list):
         raise TypeError("movements must be a list")
-    
+
     if len(movements) == 0:
         raise ValueError("movements must contain at least 1 movement object")
-    
-    if type(keep_index) is not bool:
+
+    if not isinstance(keep_index, bool):
         raise TypeError("keep_index must be bool")
-    
+
     def testing_input_movement(one_movement):
         # test for each element of `movements`
         # 1) must be pandas DataFrame
-        if type(one_movement) is not pd.core.frame.DataFrame:
+        if not isinstance(one_movement, pd.core.frame.DataFrame):
             out = 1
         # 2) must have columns named `x`, `y`, `t`
-        elif set(one_movement.keys()).issuperset(['x','y','t']) == False:
+        elif not set(one_movement.keys()).issuperset(['x', 'y', 't']):
             out = 2
         # 3) must have length greater than 1
         elif len(one_movement) <= 1:
@@ -59,47 +60,53 @@ def clean_movements(movements, keep_index=False):
         else:
             out = 0
         return(out)
-    
-    
+
     def detect_same_loc(one_movement):
         # returns indices which have same x,y-coordinates as the previous
-        x_bool = one_movement['x'][:len(one_movement)-1] == one_movement['x'][1:] 
-        y_bool = one_movement['y'][:len(one_movement)-1] == one_movement['y'][1:] 
+        x_bool = one_movement['x'][:-1] == one_movement['x'][1:]
+        y_bool = one_movement['y'][:-1] == one_movement['y'][1:]
         same_loc_bool = x_bool & y_bool
-        same_loc = [i+1 for i in range(len(same_loc_bool)) if same_loc_bool[i]]
+        same_loc = [i + 1 for i in range(len(same_loc_bool))
+                    if same_loc_bool[i]]
         return(same_loc)
 
     def detect_same_time(one_movement):
         # returns indices which have same timestamp as the previous
-        time_bool = one_movement['t'][:len(one_movement)-1] == one_movement['t'][1:] 
-        same_time = [i+1 for i in range(len(time_bool)) if time_bool[i]]
+        time_bool = one_movement['t'][:-1] == one_movement['t'][1:]
+        same_time = [i + 1 for i in range(len(time_bool))
+                     if time_bool[i]]
         return(same_time)
-    
+
     def drop_same_loc(one_movement, same_loc):
         # based on `same_loc` drops the duplicated rows
         new_one_movement = one_movement.drop(same_loc)
         if not keep_index:
             new_one_movement.index = range(len(new_one_movement))
         return(new_one_movement)
-    
+
     # testing each element of `movements` obj.
-    test_outs = [testing_input_movement(one_movement) for one_movement in movements]
-    
+    test_outs = [testing_input_movement(one_movement)
+                 for one_movement in movements]
+
     if any([True for test in test_outs if test == 1]):
-            raise TypeError("each movement object must be pandas DataFrame")
+        raise TypeError("each movement object must be pandas DataFrame")
 
     if any([True for test in test_outs if test == 2]):
-            raise ValueError("the keys of each movement object must contain 'x', 'y', 't")
+        raise ValueError(
+            "the keys of each movement object must contain 'x', 'y', 't")
 
     if any([True for test in test_outs if test == 3]):
-            raise ValueError("each movement object must contain at least 2 rows")
+        raise ValueError("each movement object must contain at least 2 rows")
 
-    same_locs  = [detect_same_loc(one_movement) for one_movement in movements]
+    same_locs = [detect_same_loc(one_movement) for one_movement in movements]
     same_times = [detect_same_time(one_movement) for one_movement in movements]
-    
-    # if any of one movement contains same timestamps in adjacent rows, raise error.
+
+    # if any of one movement contains same timestamps in adjacent rows, raise
+    # error.
     if any([len(same_time) != 0 for same_time in same_times]):
-        raise ValueError("some movement contains same timestamps in adjacent rows")
-    
-    cleaned_movements = [drop_same_loc(movement, same_loc) for movement, same_loc in zip(movements, same_locs)]
+        raise ValueError(
+            "some movement contains same timestamps in adjacent rows")
+
+    cleaned_movements = [drop_same_loc(movement, same_loc)
+                         for movement, same_loc in zip(movements, same_locs)]
     return(cleaned_movements)

--- a/mousestyles/path_diversity/clean_movements.py
+++ b/mousestyles/path_diversity/clean_movements.py
@@ -1,11 +1,11 @@
 import pandas as pd
 
-def clean_movements(movements, keep_index=None):
+def clean_movements(movements, keep_index=False):
     r"""
     Returns a list of cleaned movement objects.
 
     For each element of the input `movements` object, detects the existence of
-    rows which have i) same x,y-coordinates, or ii) same timestamps.
+    adjacent rows which have i) same x,y-coordinates, or ii) same timestamps.
     For case i), and removes the duplicated rows except for the first.
     For case ii), raises value error.
 
@@ -16,7 +16,7 @@ def clean_movements(movements, keep_index=None):
         CT, CX, CY coordinates.
         Should have length greater than 1.
 
-    kee_index : boolean
+    keep_index : boolean
         whether or not keep the original index.
         Deafalt is False.
         If false, cleaned movement object is re-indexed.
@@ -33,7 +33,7 @@ def clean_movements(movements, keep_index=None):
     >>> day_nums = [0,11,0,11,0,11]
     >>> movements = [data.load_movement(strain_num, mouse_num, day_num) for \
     >>> strain_num, mouse_num, day_num in zip(strain_nums, mouse_nums, day_nums)]
-    >>> cleaned_movements, num_same_locs = cleaning_movements(movements)
+    >>> cleaned_movements = clean_movements(movements)
     """
     
     if type(movements) is not list:
@@ -42,9 +42,6 @@ def clean_movements(movements, keep_index=None):
     if len(movements) == 0:
         raise ValueError("movements must contain at least 1 movement object")
     
-    if keep_index == None:
-        keep_index = False
-
     if type(keep_index) is not bool:
         raise TypeError("keep_index must be bool")
     

--- a/mousestyles/path_diversity/clean_movements.py
+++ b/mousestyles/path_diversity/clean_movements.py
@@ -1,0 +1,108 @@
+import pandas as pd
+
+def clean_movements(movements, keep_index=None):
+    r"""
+    Returns a list of cleaned movement objects.
+
+    For each element of the input `movements` object, detects the existence of
+    rows which have i) same x,y-coordinates, or ii) same timestamps.
+    For case i), and removes the duplicated rows except for the first.
+    For case ii), raises value error.
+
+    Parameters
+    ----------
+    movements : list
+        each element is pandas.DataFrame containing 
+        CT, CX, CY coordinates.
+        Should have length greater than 1.
+
+    kee_index : boolean
+        whether or not keep the original index.
+        Deafalt is False.
+        If false, cleaned movement object is re-indexed.
+
+    Returns
+    -------
+    cleaned-movements : list
+        each element is cleaned movement object.
+
+    Examples
+    --------
+    >>> strain_nums = [0,0,1,1,2,2]
+    >>> mouse_nums = [0,0,1,1,2,2]
+    >>> day_nums = [0,11,0,11,0,11]
+    >>> movements = [data.load_movement(strain_num, mouse_num, day_num) for \
+    >>> strain_num, mouse_num, day_num in zip(strain_nums, mouse_nums, day_nums)]
+    >>> cleaned_movements, num_same_locs = cleaning_movements(movements)
+    """
+    
+    if type(movements) is not list:
+        raise TypeError("movements must be a list")
+    
+    if len(movements) == 0:
+        raise ValueError("movements must contain at least 1 movement object")
+    
+    if keep_index == None:
+        keep_index = False
+
+    if type(keep_index) is not bool:
+        raise TypeError("keep_index must be bool")
+    
+    def testing_input_movement(one_movement):
+        # test for each element of `movements`
+        # 1) must be pandas DataFrame
+        if type(one_movement) is not pd.core.frame.DataFrame:
+            out = 1
+        # 2) must have columns named `x`, `y`, `t`
+        elif set(one_movement.keys()).issuperset(['x','y','t']) == False:
+            out = 2
+        # 3) must have length greater than 1
+        elif len(one_movement) <= 1:
+            out = 3
+        else:
+            out = 0
+        return(out)
+    
+    
+    def detect_same_loc(one_movement):
+        # returns indices which have same x,y-coordinates as the previous
+        x_bool = one_movement['x'][:len(one_movement)-1] == one_movement['x'][1:] 
+        y_bool = one_movement['y'][:len(one_movement)-1] == one_movement['y'][1:] 
+        same_loc_bool = x_bool & y_bool
+        same_loc = [i+1 for i in range(len(same_loc_bool)) if same_loc_bool[i]]
+        return(same_loc)
+
+    def detect_same_time(one_movement):
+        # returns indices which have same timestamp as the previous
+        time_bool = one_movement['t'][:len(one_movement)-1] == one_movement['t'][1:] 
+        same_time = [i+1 for i in range(len(time_bool)) if time_bool[i]]
+        return(same_time)
+    
+    def drop_same_loc(one_movement, same_loc):
+        # based on `same_loc` drops the duplicated rows
+        new_one_movement = one_movement.drop(same_loc)
+        if not keep_index:
+            new_one_movement.index = range(len(new_one_movement))
+        return(new_one_movement)
+    
+    # testing each element of `movements` obj.
+    test_outs = [testing_input_movement(one_movement) for one_movement in movements]
+    
+    if any([True for test in test_outs if test == 1]):
+            raise TypeError("each movement object must be pandas DataFrame")
+
+    if any([True for test in test_outs if test == 2]):
+            raise ValueError("the keys of each movement object must contain 'x', 'y', 't")
+
+    if any([True for test in test_outs if test == 3]):
+            raise ValueError("each movement object must contain at least 2 rows")
+
+    same_locs  = [detect_same_loc(one_movement) for one_movement in movements]
+    same_times = [detect_same_time(one_movement) for one_movement in movements]
+    
+    # if any of one movement contains same timestamps in adjacent rows, raise error.
+    if any([len(same_time) != 0 for same_time in same_times]):
+        raise ValueError("some movement contains same timestamps in adjacent rows")
+    
+    cleaned_movements = [drop_same_loc(movement, same_loc) for movement, same_loc in zip(movements, same_locs)]
+    return(cleaned_movements)

--- a/mousestyles/path_diversity/tests/test_clean_movements.py
+++ b/mousestyles/path_diversity/tests/test_clean_movements.py
@@ -2,6 +2,7 @@ import pytest
 import pandas as pd
 from mousetyles.path_diversty import clean_movements
 
+
 def test_clean_movements_input():
     # Check if function raises the correct type of errors.
     with pytest.raises(TypeError) as excinfo:
@@ -10,43 +11,44 @@ def test_clean_movements_input():
 
     with pytest.raises(ValueError) as excinfo:
         clean_movements.clean_movements([])
-    assert excinfo.value.args[0] == "movements must contain at least 1 movement object"
+    assert excinfo.value.args[
+        0] == "movements must contain at least 1 movement object"
 
     # good objects
-    m_obj1 = pd.DataFrame({'t':[2,4.5,10.5],
-                             'x':[0,1,1], 
-                             'y':[0,0,1], 
-                             'isHB':[True,True,False]})
+    m_obj1 = pd.DataFrame({'t': [2, 4.5, 10.5],
+                           'x': [0, 1, 1],
+                           'y': [0, 0, 1],
+                           'isHB': [True, True, False]})
     # not a pandas DataFrame
-    m_obj11 = {'t':[2,4.5,10.5], 
-                'x':[0,1,1], 
-                'y':[0,0,1], 
-                'isHB':[True,True,False]}
+    m_obj11 = {'t': [2, 4.5, 10.5],
+               'x': [0, 1, 1],
+               'y': [0, 0, 1],
+               'isHB': [True, True, False]}
     # no cloumn for `x`
-    m_obj12 = pd.DataFrame({'t':[2,4.5,10.5], 
-                            'y':[0,0,1], 
-                            'isHB':[True,True,False]})
+    m_obj12 = pd.DataFrame({'t': [2, 4.5, 10.5],
+                            'y': [0, 0, 1],
+                            'isHB': [True, True, False]})
 
     # good object
-    m_obj2 = pd.DataFrame({'t':[2,4.5,10.5], 
-                            'x':[0,1,1], 
-                            'y':[0,0,1], 
-                            'isHB':[True,True,False]})
+    m_obj2 = pd.DataFrame({'t': [2, 4.5, 10.5],
+                           'x': [0, 1, 1],
+                           'y': [0, 0, 1],
+                           'isHB': [True, True, False]})
     # length is only 1
-    m_obj21 = pd.DataFrame({'t':[2], 
-                            'x':[0], 
-                            'y':[0]})
+    m_obj21 = pd.DataFrame({'t': [2],
+                            'x': [0],
+                            'y': [0]})
     # having same timestamps
-    m_obj22 = pd.DataFrame({'t':[2,2,10.5], 
-                            'x':[0,1,1], 
-                            'y':[0,0,1], 
-                            'isHB':[True,True,False]})
+    m_obj22 = pd.DataFrame({'t': [2, 2, 10.5],
+                            'x': [0, 1, 1],
+                            'y': [0, 0, 1],
+                            'isHB': [True, True, False]})
 
     test_obj = [m_obj1, m_obj2]
-    test_obj11 = [m_obj11,m_obj2]
-    test_obj12 = [m_obj12,m_obj2]
-    test_obj21 = [m_obj1,m_obj21]
-    test_obj22 = [m_obj1,m_obj22]
+    test_obj11 = [m_obj11, m_obj2]
+    test_obj12 = [m_obj12, m_obj2]
+    test_obj21 = [m_obj1, m_obj21]
+    test_obj22 = [m_obj1, m_obj22]
 
     with pytest.raises(TypeError) as excinfo:
         clean_movements.clean_movements(test_obj, 1)
@@ -54,48 +56,53 @@ def test_clean_movements_input():
 
     with pytest.raises(TypeError) as excinfo:
         clean_movements.clean_movements(test_obj11)
-    assert excinfo.value.args[0] == "each movement object must be pandas DataFrame"
+    assert excinfo.value.args[
+        0] == "each movement object must be pandas DataFrame"
 
     with pytest.raises(ValueError) as excinfo:
         clean_movements.clean_movements(test_obj12)
-    assert excinfo.value.args[0] == "the keys of each movement object must contain 'x', 'y', 't"
+    assert excinfo.value.args[
+        0] == "the keys of each movement object must contain 'x', 'y', 't"
 
     with pytest.raises(ValueError) as excinfo:
         clean_movements.clean_movements(test_obj21)
-    assert excinfo.value.args[0] == "each movement object must contain at least 2 rows"
+    assert excinfo.value.args[
+        0] == "each movement object must contain at least 2 rows"
 
     with pytest.raises(ValueError) as excinfo:
         clean_movements.clean_movements(test_obj22)
-    assert excinfo.value.args[0] == "some movement contains same timestamps in adjacent rows"
+    assert excinfo.value.args[
+        0] == "some movement contains same timestamps in adjacent rows"
 
 
 def test_clean_movements():
     # 4th and 5th rows must be dropeed
-    m_obj1 = pd.DataFrame({'t':[1,1.4,2,3,4,4.3,5,5.1], 
-                            'x':[0,1,1,1,1,2,2,2],
-                            'y':[0,0,1,1,1,-1,0,-1],
-                            'isHB':[True,True,False,True,True,True,True,True]})
+    m_obj1 = pd.DataFrame({'t': [1, 1.4, 2, 3, 4, 4.3, 5, 5.1],
+                           'x': [0, 1, 1, 1, 1, 2, 2, 2],
+                           'y': [0, 0, 1, 1, 1, -1, 0, -1],
+                           'isHB': [True, True, False, True, True, True,
+                                    True, True]})
     # 2 length object. 2nd row must be dropeed
-    m_obj2 = pd.DataFrame({'t':[2,4], 
-                            'x':[10,10], 
-                            'y':[10,10]})
-    test_obj = [m_obj1,m_obj2]
+    m_obj2 = pd.DataFrame({'t': [2, 4],
+                           'x': [10, 10],
+                           'y': [10, 10]})
+    test_obj = [m_obj1, m_obj2]
 
     output = clean_movements.clean_movements(test_obj)
     output_same_ind = clean_movements.clean_movements(test_obj, True)
 
     # desired outputs
-    comp1 = pd.DataFrame({'t':[1,1.4,2,4.3,5,5.1], 
-                            'x':[0,1,1,2,2,2],
-                            'y':[0,0,1,-1,0,-1],
-                            'isHB':[True,True,False,True,True,True]})
-    comp2 = pd.DataFrame({'t':[2], 
-                            'x':[10], 
-                            'y':[10]})
+    comp1 = pd.DataFrame({'t': [1, 1.4, 2, 4.3, 5, 5.1],
+                          'x': [0, 1, 1, 2, 2, 2],
+                          'y': [0, 0, 1, -1, 0, -1],
+                          'isHB': [True, True, False, True, True, True]})
+    comp2 = pd.DataFrame({'t': [2],
+                          'x': [10],
+                          'y': [10]})
 
     assert (output[0] == comp1).all().all()
     assert (output[1] == comp2).all().all()
-    
+
     # see index-match
-    comp1.index = [0,1,2,5,6,7]
+    comp1.index = [0, 1, 2, 5, 6, 7]
     assert (output_same_ind[0] == comp1).all().all()

--- a/mousestyles/path_diversity/tests/test_clean_movements.py
+++ b/mousestyles/path_diversity/tests/test_clean_movements.py
@@ -1,0 +1,101 @@
+import pytest
+import pandas as pd
+from mousetyles.path_diversty import clean_movements
+
+def test_clean_movements_input():
+    # Check if function raises the correct type of errors.
+    with pytest.raises(TypeError) as excinfo:
+        clean_movements.clean_movements(1)
+    assert excinfo.value.args[0] == 'movements must be a list'
+
+    with pytest.raises(ValueError) as excinfo:
+        clean_movements.clean_movements([])
+    assert excinfo.value.args[0] == "movements must contain at least 1 movement object"
+
+    # good objects
+    m_obj1 = pd.DataFrame({'t':[2,4.5,10.5],
+                             'x':[0,1,1], 
+                             'y':[0,0,1], 
+                             'isHB':[True,True,False]})
+    # not a pandas DataFrame
+    m_obj11 = {'t':[2,4.5,10.5], 
+                'x':[0,1,1], 
+                'y':[0,0,1], 
+                'isHB':[True,True,False]}
+    # no cloumn for `x`
+    m_obj12 = pd.DataFrame({'t':[2,4.5,10.5], 
+                            'y':[0,0,1], 
+                            'isHB':[True,True,False]})
+
+    # good object
+    m_obj2 = pd.DataFrame({'t':[2,4.5,10.5], 
+                            'x':[0,1,1], 
+                            'y':[0,0,1], 
+                            'isHB':[True,True,False]})
+    # length is only 1
+    m_obj21 = pd.DataFrame({'t':[2], 
+                            'x':[0], 
+                            'y':[0]})
+    # having same timestamps
+    m_obj22 = pd.DataFrame({'t':[2,2,10.5], 
+                            'x':[0,1,1], 
+                            'y':[0,0,1], 
+                            'isHB':[True,True,False]})
+
+    test_obj = [m_obj1, m_obj2]
+    test_obj11 = [m_obj11,m_obj2]
+    test_obj12 = [m_obj12,m_obj2]
+    test_obj21 = [m_obj1,m_obj21]
+    test_obj22 = [m_obj1,m_obj22]
+
+    with pytest.raises(TypeError) as excinfo:
+        clean_movements.clean_movements(test_obj, 1)
+    assert excinfo.value.args[0] == "keep_index must be bool"
+
+    with pytest.raises(TypeError) as excinfo:
+        clean_movements.clean_movements(test_obj11)
+    assert excinfo.value.args[0] == "each movement object must be pandas DataFrame"
+
+    with pytest.raises(ValueError) as excinfo:
+        clean_movements.clean_movements(test_obj12)
+    assert excinfo.value.args[0] == "the keys of each movement object must contain 'x', 'y', 't"
+
+    with pytest.raises(ValueError) as excinfo:
+        clean_movements.clean_movements(test_obj21)
+    assert excinfo.value.args[0] == "each movement object must contain at least 2 rows"
+
+    with pytest.raises(ValueError) as excinfo:
+        clean_movements.clean_movements(test_obj22)
+    assert excinfo.value.args[0] == "some movement contains same timestamps in adjacent rows"
+
+
+def test_clean_movements():
+    # 4th and 5th rows must be dropeed
+    m_obj1 = pd.DataFrame({'t':[1,1.4,2,3,4,4.3,5,5.1], 
+                            'x':[0,1,1,1,1,2,2,2],
+                            'y':[0,0,1,1,1,-1,0,-1],
+                            'isHB':[True,True,False,True,True,True,True,True]})
+    # 2 length object. 2nd row must be dropeed
+    m_obj2 = pd.DataFrame({'t':[2,4], 
+                            'x':[10,10], 
+                            'y':[10,10]})
+    test_obj = [m_obj1,m_obj2]
+
+    output = clean_movements.clean_movements(test_obj)
+    output_same_ind = clean_movements.clean_movements(test_obj, True)
+
+    # desired outputs
+    comp1 = pd.DataFrame({'t':[1,1.4,2,4.3,5,5.1], 
+                            'x':[0,1,1,2,2,2],
+                            'y':[0,0,1,-1,0,-1],
+                            'isHB':[True,True,False,True,True,True]})
+    comp2 = pd.DataFrame({'t':[2], 
+                            'x':[10], 
+                            'y':[10]})
+
+    assert (output[0] == comp1).all().all()
+    assert (output[1] == comp2).all().all()
+    
+    # see index-match
+    comp1.index = [0,1,2,5,6,7]
+    assert (output_same_ind[0] == comp1).all().all()

--- a/mousestyles/path_diversity/tests/test_clean_movements.py
+++ b/mousestyles/path_diversity/tests/test_clean_movements.py
@@ -1,6 +1,6 @@
 import pytest
 import pandas as pd
-from mousetyles.path_diversty import clean_movements
+from mousestyles.path_diversity import clean_movements
 
 
 def test_clean_movements_input():


### PR DESCRIPTION
I added the function to detect and remove duplicated rows in raw data, meaning the rows which have exactly same x,y-coordinates with different timestamps as their previous rows. Those rows must be removed prior to calculating angles within each path, or otherwise `compute_angles` function would return an error. For details, see issue #122. 
@aksam-ahmad please review.