### PR TITLE
MRG: Update to remove deprecation warning

### DIFF
--- a/mousestyles/data/__init__.py
+++ b/mousestyles/data/__init__.py
@@ -215,7 +215,7 @@ def load_intervals(feature):
         dt_sub["stop"] = sub[:, 1]
         dt = pd.concat([dt, dt_sub])
     # sort based on strain, mouse and day
-    dt = dt.sort(["strain", "mouse", "day"])
+    dt = dt.sort_values(["strain", "mouse", "day"])
     dt.index = range(dt.shape[0])
     return dt
 


### PR DESCRIPTION
data.load_intervals() was returning a deprecation
warning from using a deprecated pandas sort function.
The function is now updated to use the recommended version.